### PR TITLE
Fix issue #16

### DIFF
--- a/sapi4.cpp
+++ b/sapi4.cpp
@@ -228,21 +228,21 @@ extern __declspec(dllexport) BOOL GetTTS(
 	WORD Pitch,
 	DWORD Speed,
 	LPCSTR Text,
-	PUINT64 Len
+	PUINT64 Len,
+	LPSTR* OutText
 )
 {
 	WCHAR wszFile[17] = L"";
-	char rndFile[17] = "";
 	for (int x = 0;x < 16;x++) {
 		if (rand() % 2 == 0)
-			rndFile[x] = 'A' + (rand() % 26);
+			(*OutText)[x] = 'A' + (rand() % 26);
 		else
-			rndFile[x] = 'a' + (rand() % 26);
+			(*OutText)[x] = 'a' + (rand() % 26);
 	}
 	
-	printf("%s\n", rndFile);
+	(*OutText)[16] = '\0';
 
-	MultiByteToWideChar(CP_ACP, 0, rndFile, -1, wszFile, sizeof(wszFile) / sizeof(WCHAR));
+	MultiByteToWideChar(CP_ACP, 0, *OutText, -1, wszFile, sizeof(wszFile) / sizeof(WCHAR));
 	if (pVoiceInfo->pIAF->Set(wszFile, 1)) {
 		return FALSE;
 	}

--- a/sapi4.cpp
+++ b/sapi4.cpp
@@ -229,20 +229,20 @@ extern __declspec(dllexport) BOOL GetTTS(
 	DWORD Speed,
 	LPCSTR Text,
 	PUINT64 Len,
-	LPSTR* OutText
+	LPSTR* OutFile
 )
 {
 	WCHAR wszFile[17] = L"";
 	for (int x = 0;x < 16;x++) {
 		if (rand() % 2 == 0)
-			(*OutText)[x] = 'A' + (rand() % 26);
+			(*OutFile)[x] = 'A' + (rand() % 26);
 		else
-			(*OutText)[x] = 'a' + (rand() % 26);
+			(*OutFile)[x] = 'a' + (rand() % 26);
 	}
 	
-	(*OutText)[16] = '\0';
+	(*OutFile)[16] = '\0';
 
-	MultiByteToWideChar(CP_ACP, 0, *OutText, -1, wszFile, sizeof(wszFile) / sizeof(WCHAR));
+	MultiByteToWideChar(CP_ACP, 0, *OutFile, -1, wszFile, sizeof(wszFile) / sizeof(WCHAR));
 	if (pVoiceInfo->pIAF->Set(wszFile, 1)) {
 		return FALSE;
 	}

--- a/sapi4.hpp
+++ b/sapi4.hpp
@@ -49,7 +49,8 @@ extern __declspec(dllexport) BOOL GetTTS(
 	WORD Pitch,
 	DWORD Speed,
 	LPCSTR Text,
-	PUINT64 Len
+	PUINT64 Len,
+	LPSTR* OutText
 );
 
 extern __declspec(dllexport) VOID DeinitializeForVoice(

--- a/sapi4.hpp
+++ b/sapi4.hpp
@@ -50,7 +50,7 @@ extern __declspec(dllexport) BOOL GetTTS(
 	DWORD Speed,
 	LPCSTR Text,
 	PUINT64 Len,
-	LPSTR* OutText
+	LPSTR* OutFile
 );
 
 extern __declspec(dllexport) VOID DeinitializeForVoice(

--- a/sapi4out.cpp
+++ b/sapi4out.cpp
@@ -15,5 +15,10 @@ int main(int argc, char** argv)
 	}
 
 	UINT64 Len;
-	GetTTS(&VoiceInfo, atoi(argv[2]), atoi(argv[3]), argv[4], &Len);
+	
+	LPSTR outFile = (LPSTR)malloc(17);
+	GetTTS(&VoiceInfo, atoi(argv[2]), atoi(argv[3]), argv[4], &Len, &outFile);
+	
+	printf("%s\n", outFile);
+	free(outFile);
 }

--- a/sapi4out.cpp
+++ b/sapi4out.cpp
@@ -16,9 +16,8 @@ int main(int argc, char** argv)
 
 	UINT64 Len;
 	
-	LPSTR outFile = (LPSTR)malloc(17);
+	LPSTR outFile[17];
 	GetTTS(&VoiceInfo, atoi(argv[2]), atoi(argv[3]), argv[4], &Len, &outFile);
 	
 	printf("%s\n", outFile);
-	free(outFile);
 }


### PR DESCRIPTION
Specific voice engines such as L&H tries to somehow redirect stdout of the executing program which results programs which try to capture the stdout not actually capturing it.

For example, printing something before and after `GetTTS` will get prints executed as normal, but any prints inside `GetTTS` would produce the strange behavior.

Another example - powershell would display the print executed in `GetTTS`, but would refuse to capture it into a file (`./sapi4out.exe "Adult Female #1 British English (L&H)" 170 180 "asd" >> out.txt`).

Solution is to pass generated file name through routine arguments and print it after TTS if fully complete.