### PR TITLE
Cleanup, print only if stderr is not empty

### DIFF
--- a/SAPI4_web/dub.json
+++ b/SAPI4_web/dub.json
@@ -4,7 +4,7 @@
 		"User"
 	],
 	"dependencies": {
-		"vibe-d": "~>0.8.1-beta.2",
+		"vibe-d": "~>0.9.5",
 		"web-config": "~>1.1.0"
 	},
 	"description": "MSSAM",

--- a/SAPI4_web/source/app.d
+++ b/SAPI4_web/source/app.d
@@ -142,23 +142,15 @@ class SAMService
 				return;
 			}
 
-			logInfo("pre pipe");
-
 			auto proc = pipeProcess(["sapi4out.exe", voice, to!string(pitch), to!string(speed), cast(string)text], Redirect.all);
-
-			logInfo("post pipe");
 
 			auto executedAt = Clock.currTime;
 			auto wait = tryWait(proc.pid);
-
-			logInfo("post wait");
 
 			while (!wait.terminated && Clock.currTime - executedAt < dur!"seconds"(10)) {
 				wait = tryWait(proc.pid);
 				sleep(dur!"msecs"(100));
 			}
-
-			logInfo("done waiting");
 
 			if (!wait.terminated) {
 				kill(proc.pid);
@@ -168,8 +160,6 @@ class SAMService
 				res.writeBody("Please reformat your text", 400);
 				return;
 			}
-
-			logInfo("pre outp");
 			
 			string outputErr;
 			foreach (line; proc.stderr.byLine)
@@ -179,15 +169,14 @@ class SAMService
 			foreach (line; proc.stdout.byLine)
 				output ~= line.idup;
 			
-			logInfo("got outp \"" ~ outputErr ~ "\"");
+			if (outputErr != "")
+				logInfo("got error output \"" ~ outputErr ~ "\"");
 
 			auto file = output.replace("err:xrandr:xrandr12_init_modes Failed to get primary CRTC info.", "").strip();
 
 			if (file == "") {
 				core.stdc.stdlib.exit(1);
 			}
-
-			logInfo("pre openfile");
 
 			auto fs = openFile(file, FileMode.read);
 


### PR DESCRIPTION
Currently program produces too much output per audio generation

Also, older versions of vibe-d doesn't seem to compile with never versions of ldc2, so update that as well.