### PR TITLE
Call memset() to zero out VOICE_INFO

### DIFF
--- a/sapi4.hpp
+++ b/sapi4.hpp
@@ -28,16 +28,16 @@ typedef CTestNotify *PCTestNotify;
 
 
 typedef struct _VOICE_INFO {
-	PITTSCENTRAL	pITTSCentral = NULL;
+	PITTSCENTRAL	pITTSCentral;
 	TTSMODEINFO		ModeInfo;
-	PIAUDIOFILE		pIAF = NULL;
-	PITTSATTRIBUTES	pITTSAttributes = NULL;
+	PIAUDIOFILE		pIAF;
+	PITTSATTRIBUTES	pITTSAttributes;
 
 	WORD defPitch, minPitch, maxPitch;
 	DWORD defSpeed, minSpeed, maxSpeed;
 
 	PCTestNotify pNotify;
-	BOOL VoiceDone = FALSE;
+	BOOL VoiceDone;
 } VOICE_INFO, *PVOICE_INFO;
 
 extern __declspec(dllexport) VOID TTSCleanup(

--- a/sapi4limits.cpp
+++ b/sapi4limits.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv)
 {
 	if (argc == 2) {
 		VOICE_INFO VoiceInfo;
+		memset((void *)&VoiceInfo, 0, sizeof(VoiceInfo));
 		if (!InitializeForVoice(argv[1], &VoiceInfo)) {
 			return 0;
 		}

--- a/sapi4out.cpp
+++ b/sapi4out.cpp
@@ -10,6 +10,7 @@
 int main(int argc, char** argv)
 {
 	VOICE_INFO VoiceInfo;
+	memset((void *)&VoiceInfo, 0, sizeof(VoiceInfo));
 	if (!InitializeForVoice(argv[1], &VoiceInfo)) {
 		return 0;
 	}


### PR DESCRIPTION
The current code does not compile with older versions of Microsoft Visual C++ and Visual Studio because initializing struct members is not allowed. This pull request resolves this by removing initialization within the struct and calling memset() explicitly.